### PR TITLE
2026 05 01 dep updates

### DIFF
--- a/client/src/main/scala/org/scalastr/client/NostrClient.scala
+++ b/client/src/main/scala/org/scalastr/client/NostrClient.scala
@@ -1,15 +1,15 @@
 package org.scalastr.client
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.ws._
-import akka.http.scaladsl.settings._
-import akka.stream.OverflowStrategy
-import akka.stream.scaladsl._
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.tor.Socks5ClientTransport
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.ws._
+import org.apache.pekko.http.scaladsl.settings._
+import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.scaladsl._
 import org.scalastr.core._
 import play.api.libs.json._
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-akka {
+pekko {
     log-dead-letters = 10
     log-dead-letters-during-shutdown = off
     stdout-loglevel = "INFO"

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -4,7 +4,7 @@ import xerial.sbt.Sonatype.GitHubHosting
 import scala.util.Properties
 
 val scala2_12 = "2.12.15"
-val scala2_13 = "2.13.8"
+val scala2_13 = "2.13.18"
 
 ThisBuild / scmInfo := Some(
   ScmInfo(

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -25,7 +25,7 @@ ThisBuild / developers := List(
 ThisBuild / organization := "org.scalastr"
 
 ThisBuild / licenses := List(
-  "MIT" -> new URL("https://opensource.org/licenses/MIT"))
+  "MIT" -> url("https://opensource.org/licenses/MIT"))
 
 ThisBuild / homepage := Some(url("https://github.com/benthecarman/scalastr"))
 
@@ -48,6 +48,5 @@ ThisBuild / dynverSeparator := "-"
 //https://github.com/sbt/sbt/pull/5153
 //https://github.com/bitcoin-s/bitcoin-s/pull/2194
 Global / excludeLintKeys ++= Set(
-  com.typesafe.sbt.packager.Keys.maintainer,
   Keys.mainClass
 )

--- a/nip5/src/main/scala/org/scalastr/nip5/Nip5Client.scala
+++ b/nip5/src/main/scala/org/scalastr/nip5/Nip5Client.scala
@@ -1,12 +1,12 @@
 package org.scalastr.nip5
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.{Http, HttpExt}
-import akka.http.scaladsl.client.RequestBuilding.Get
-import akka.http.scaladsl.model.HttpRequest
-import akka.util.ByteString
 import grizzled.slf4j.Logging
 import org.bitcoins.crypto.SchnorrPublicKey
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.{Http, HttpExt}
+import org.apache.pekko.http.scaladsl.client.RequestBuilding.Get
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.util.ByteString
 import org.scalastr.core.NostrPublicKey
 import play.api.libs.json.Json
 

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -8,7 +8,7 @@ import scala.util.Properties
 object CommonSettings {
 
   lazy val settings: Vector[Setting[_]] = Vector(
-    scalaVersion := "2.13.17",
+    scalaVersion := (ThisBuild / scalaVersion).value,
     organization := "org.scalastr",
     homepage := Some(url("https://github.com/benthecarman/scalastr")),
     developers := List(

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -1,4 +1,3 @@
-import com.typesafe.sbt.packager.Keys.maintainer
 import sbt.Keys._
 import sbt._
 import xerial.sbt.Sonatype.autoImport._
@@ -9,11 +8,9 @@ import scala.util.Properties
 object CommonSettings {
 
   lazy val settings: Vector[Setting[_]] = Vector(
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.17",
     organization := "org.scalastr",
     homepage := Some(url("https://github.com/benthecarman/scalastr")),
-    maintainer.withRank(
-      KeyRanks.Invisible) := "benthecarman <benthecarman@live.com>",
     developers := List(
       Developer(
         "benthecarman",
@@ -42,7 +39,7 @@ object CommonSettings {
     Test / console / scalacOptions ++= (Compile / console / scalacOptions).value,
     Test / scalacOptions ++= testCompilerOpts(scalaVersion.value),
     licenses += ("MIT", url("https://opensource.org/licenses/MIT")),
-    resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+    resolvers += Resolver.sonatypeCentralSnapshots
   )
 
   private val commonCompilerOpts = {

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -39,7 +39,7 @@ object CommonSettings {
     Test / console / scalacOptions ++= (Compile / console / scalacOptions).value,
     Test / scalacOptions ++= testCompilerOpts(scalaVersion.value),
     licenses += ("MIT", url("https://opensource.org/licenses/MIT")),
-    resolvers += Resolver.sonatypeCentralSnapshots
+    resolvers += "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots"
   )
 
   private val commonCompilerOpts = {

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -4,7 +4,7 @@ object Deps {
 
   object V {
     val pekkoHttpV = "1.3.0"
-    val pekkoV = "1.6.0"
+    val pekkoV = "1.4.0"
 
     val bitcoinsV = "1.9.12"
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -10,7 +10,7 @@ object Deps {
 
     val playV = "2.9.4"
 
-    val testContainersV = "0.40.12"
+    val testContainersV = "0.44.1"
 
     val grizzledSlf4jV = "1.3.4"
   }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -3,11 +3,10 @@ import sbt._
 object Deps {
 
   object V {
-    val akkaV = "10.2.10"
-    val akkaStreamV = "2.6.20"
-    val akkaActorV: String = akkaStreamV
+    val pekkoHttpV = "1.0.1"
+    val pekkoV = "1.0.2"
 
-    val bitcoinsV = "1.9.7-412-195cfbd2-SNAPSHOT"
+    val bitcoinsV = "1.9.8"
 
     val playV = "2.9.4"
 
@@ -21,17 +20,17 @@ object Deps {
     val playJson =
       "com.typesafe.play" %% "play-json" % V.playV withSources () withJavadoc ()
 
-    val akkaHttp =
-      "com.typesafe.akka" %% "akka-http" % V.akkaV withSources () withJavadoc ()
+    val pekkoHttp =
+      "org.apache.pekko" %% "pekko-http" % V.pekkoHttpV withSources () withJavadoc ()
 
-    val akkaStream =
-      "com.typesafe.akka" %% "akka-stream" % V.akkaStreamV withSources () withJavadoc ()
+    val pekkoStream =
+      "org.apache.pekko" %% "pekko-stream" % V.pekkoV withSources () withJavadoc ()
 
-    val akkaActor =
-      "com.typesafe.akka" %% "akka-actor" % V.akkaStreamV withSources () withJavadoc ()
+    val pekkoActor =
+      "org.apache.pekko" %% "pekko-actor" % V.pekkoV withSources () withJavadoc ()
 
-    val akkaSlf4j =
-      "com.typesafe.akka" %% "akka-slf4j" % V.akkaStreamV withSources () withJavadoc ()
+    val pekkoSlf4j =
+      "org.apache.pekko" %% "pekko-slf4j" % V.pekkoV withSources () withJavadoc ()
 
     val grizzledSlf4j =
       "org.clapper" %% "grizzled-slf4j" % V.grizzledSlf4jV withSources () withJavadoc ()
@@ -67,10 +66,11 @@ object Deps {
 
   val nip5: List[ModuleID] = List(
     Compile.bitcoinsTor,
-    Compile.akkaActor,
-    Compile.akkaHttp,
-    Compile.akkaStream,
-    Compile.akkaSlf4j
+    Compile.pekkoActor,
+    Compile.pekkoHttp,
+    Compile.pekkoStream,
+    Compile.pekkoSlf4j,
+    Compile.grizzledSlf4j
   )
 
   val nip5Test: List[ModuleID] = List(
@@ -79,10 +79,11 @@ object Deps {
 
   val client: List[ModuleID] = List(
     Compile.bitcoinsTor,
-    Compile.akkaActor,
-    Compile.akkaHttp,
-    Compile.akkaStream,
-    Compile.akkaSlf4j
+    Compile.pekkoActor,
+    Compile.pekkoHttp,
+    Compile.pekkoStream,
+    Compile.pekkoSlf4j,
+    Compile.grizzledSlf4j
   )
 
   val testkit: List[ModuleID] = List(

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -6,7 +6,7 @@ object Deps {
     val pekkoHttpV = "1.0.1"
     val pekkoV = "1.0.2"
 
-    val bitcoinsV = "1.9.11"
+    val bitcoinsV = "1.9.12"
 
     val playV = "2.9.4"
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -6,7 +6,7 @@ object Deps {
     val pekkoHttpV = "1.0.1"
     val pekkoV = "1.0.2"
 
-    val bitcoinsV = "1.9.10"
+    val bitcoinsV = "1.9.11"
 
     val playV = "2.9.4"
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -6,7 +6,7 @@ object Deps {
     val pekkoHttpV = "1.0.1"
     val pekkoV = "1.0.2"
 
-    val bitcoinsV = "1.9.8"
+    val bitcoinsV = "1.9.10"
 
     val playV = "2.9.4"
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -3,8 +3,8 @@ import sbt._
 object Deps {
 
   object V {
-    val pekkoHttpV = "1.0.1"
-    val pekkoV = "1.0.2"
+    val pekkoHttpV = "1.3.0"
+    val pekkoV = "1.6.0"
 
     val bitcoinsV = "1.9.12"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.1
+sbt.version = 1.12.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,10 +8,10 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.2")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.4")
+//addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.4")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
+//addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")

--- a/publish.sbt
+++ b/publish.sbt
@@ -24,7 +24,7 @@ ThisBuild / developers := List(
 ThisBuild / description := "A barebones scala nostr library"
 
 ThisBuild / licenses := List(
-  "MIT" -> new URL("https://opensource.org/licenses/MIT"))
+  "MIT" -> url("https://opensource.org/licenses/MIT"))
 ThisBuild / homepage := Some(url("https://github.com/benthecarman/scalastr/"))
 
 // Remove all additional repository other than Maven Central from POM


### PR DESCRIPTION
Saw your bitcoin villains talk and thought I would upgrade these deps. I'm going to do opreturnbot next - but AFAICT opreturnbot depends on this project publish (locally?).

My understanding is this project is a library to be published and not have binaries built for. If this isn't the case lmk how to build the binaries and test it. 

The biggest change here is switching from akka to pekko. Lightbend moved to a [closed source model](https://akka.io/blog/why-we-are-changing-the-license-for-akka) and the community forked to create [pekko](https://news.apache.org/foundation/entry/apache-software-foundation-announces-new-top-level-project-apache-pekko) which is a fork of akka before it went closed source.

Here is the AI generated summary of these changes

## PR Summary

- Migrates runtime/concurrency stack from Akka to Apache Pekko across dependencies and code (`project/Deps.scala`, `client/src/main/scala/org/scalastr/client/NostrClient.scala`, `nip5/src/main/scala/org/scalastr/nip5/Nip5Client.scala`).
- Updates runtime config namespace from `akka` to `pekko` (`core/src/main/resources/reference.conf`).
- Bumps key dependency versions, including `bitcoin-s` to `1.9.12`, `pekko` to `1.4.0`, `pekko-http` to `1.3.0`, and `testcontainers-scala` to `0.44.1` (`project/Deps.scala`).
- Adjusts SBT/plugin setup for boot/build compatibility, including disabling legacy web pipeline plugins (`project/plugins.sbt`).
- Cleans up build configuration consistency and resolver usage in build settings (`project/CommonSettings.scala` and related SBT config files).